### PR TITLE
Switch to grid layout for images

### DIFF
--- a/motherless.com-improved.user.js
+++ b/motherless.com-improved.user.js
@@ -224,6 +224,12 @@ GM_addStyle(`
   #categories-page.inner .filtered-include { display: none !important; }
 }`);
 
+GM_addStyle(`
+  .ml-masonry-images.masonry-columns-4 .content-inner { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ml-masonry-images.masonry-columns-6 .content-inner { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .ml-masonry-images.masonry-columns-8 .content-inner { display: grid; grid-template-columns: repeat(8, minmax(0, 1fr)); }
+`)
+
 //====================================================================================================
 
 const SCROLL_RESET_DELAY = 50;


### PR DESCRIPTION
Changes image layout to order pictures left->right then top->bottom instead of the reverse. This avoids changing where images are when new images are loaded.

This change forces images to have the same height but I think it's a good tradeoff.