### PR TITLE
Fix duplicate entries in "related galleries" on motherless

### DIFF
--- a/src/userscripts/scripts/motherless.ts
+++ b/src/userscripts/scripts/motherless.ts
@@ -142,12 +142,13 @@ async function desktopAddMobGalleries() {
   const galleries = document.querySelector('.media-related-galleries');
   if (!galleries) return;
 
-  const galleriesContainer = galleries.querySelector('.content-inner') as HTMLElement;
-  const galleriesCount = galleries.querySelectorAll('.gallery-container').length;
   const mobDom = await fetchWith(window.location.href, { type: 'html', mobile: true });
   const mobGalleries = (mobDom as HTMLElement).querySelectorAll<HTMLElement>(
     '.ml-gallery-thumb',
   );
+
+  const galleriesContainer = galleries.querySelector('.content-inner') as HTMLElement;
+  const galleriesCount = galleries.querySelectorAll('.gallery-container').length;
 
   for (const [i, x] of mobGalleries.entries()) {
     if (i > galleriesCount - 1) {

--- a/src/userscripts/scripts/motherless.ts
+++ b/src/userscripts/scripts/motherless.ts
@@ -152,7 +152,10 @@ async function desktopAddMobGalleries() {
 
   for (const [i, x] of mobGalleries.entries()) {
     if (i > galleriesCount - 1) {
-      galleriesContainer.append(mobileGalleryToDesktop(x));
+      const mobGallery = mobileGalleryToDesktop(x);
+      const mobGalleryId = mobGallery.querySelector('a').href.split('/').at(-1);
+      if (galleriesContainer.querySelector(`a[href*=${mobGalleryId}]`)) continue;
+      galleriesContainer.append(mobGallery);
     }
   }
 }


### PR DESCRIPTION
The "related galleries" section had duplicate entries after the mobile galleries were appended. This because `galleriesCount` was always zero, as they had not yet been loaded when the code ran. By moving it after the fetch, it allows enough time for the desktop galleries to finish loading.

It's still not ideal, since it's still possible for the desktop galleries to not have finished loading yet, but it does raise the likelihood of it working.